### PR TITLE
switch neo4j-helm to master branch

### DIFF
--- a/labs-docs.yml
+++ b/labs-docs.yml
@@ -9,7 +9,7 @@ content:
   # - url: https://gitlab.com/yuzutech/demo-antora/neo4j/apoc.git
   #   branches: ['4.0', '3.5']
   - url: https://github.com/neo4j-contrib/neo4j-helm.git
-    branches: ['antora']
+    branches: ['master']
     start_path: doc/docs
   - url: https://github.com/neo4j-contrib/neo4j-apoc-procedures
     branches: ['4.1']


### PR DESCRIPTION
Antora was a dev branch.  All of those docs got merged to master, and that's where the official stuff will reside from now on, so I wanted to update this pointer so that this repo only ever sees the approved / finalized docs