### PR TITLE
Add a script to check missing attribute

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npm run build 2> >(tee build-stderr.log)

--- a/lint/asciidoctor-errors.sh
+++ b/lint/asciidoctor-errors.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+errors_count=$(cat "$DIR/../build-stderr.log" | grep "asciidoctor: ERROR:" | wc -l)
+
+if [ "$errors_count" != "0" ]; then
+  echo "Found ${errors_count} errors, aborting!"
+  exit 1
+fi
+
+exit 0

--- a/lint/asciidoctor-warnings.sh
+++ b/lint/asciidoctor-warnings.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-missing_attributes=$(cat "$DIR/../build-stderr.log" | grep "skipping reference to missing attribute" | cut -d' ' -f8)
+missing_attributes=$(cat "$DIR/../build-stderr.log" | grep "asciidoctor: WARNING: skipping reference to missing attribute:" | cut -d' ' -f8)
 missing_attributes_list=$(echo $missing_attributes | tr '\n' ' ')
 read -a missing_attributes_array <<< $missing_attributes_list
 

--- a/lint/asciidoctor-warnings.sh
+++ b/lint/asciidoctor-warnings.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+missing_attributes=$(cat "$DIR/../build-stderr.log" | grep "skipping reference to missing attribute" | cut -d' ' -f8)
+missing_attributes_list=$(echo $missing_attributes | tr '\n' ' ')
+read -a missing_attributes_array <<< $missing_attributes_list
+
+if [ ! -z "$missing_attributes" ]; then
+  echo "Found ${#missing_attributes_array[@]} unresolved attributes"
+  uniq_missing_attributes=$(echo "$missing_attributes" | sort | uniq)
+  for missing_attr in $uniq_missing_attributes
+  do
+    echo "Unresolved attribute {$missing_attr} found in:"
+    grep -i "{$missing_attr}" "$DIR/../build/site/"* -R | cut -d':' -f1 | uniq | sed -e "s/^.*\/build\/site\///" | sed -e 's/^/  /'
+  done
+  exit 1
+fi
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "migrate:includes": "cp -R /Users/adam/neo4j/developer-resources/language-guides/_includes/ asciidoc/developer/modules/ROOT/pages/_includes",
     "migrate:menu": "node migrate/menu.js",
     "migrate:docs": "node migrate/docs.js",
-    "lint": "npm run lint-xref",
+    "lint": "npm run lint-xref && npm run lint-asciidoc",
     "lint-xref": "npm run lint-xref:unversioned && npm run lint-xref:labs-docs",
     "lint-xref:unversioned": "antora --generator @antora/xref-validator unversioned.yml",
-    "lint-xref:labs-docs": "antora --generator @antora/xref-validator labs-docs.yml"
+    "lint-xref:labs-docs": "antora --generator @antora/xref-validator labs-docs.yml",
+    "lint-asciidoc": "./build.sh && ./lint/asciidoctor-errors.sh && ./lint/asciidoctor-warnings.sh"
   },
   "author": "Adam Cowley <adam+github@neo4j.com>",
   "license": "ISC",


### PR DESCRIPTION
I've added two scripts:

`./build.sh`

This script will basically run `npm run build`. The stderr will be sent to the console and to the file `build-stderr.log`.

`./lint/asciidoctor-warnings.sh`

This script will read the file `build-stderr.log` and display an informative message.
If the `build-stderr.log` contains "skipping reference to missing attribute", it will exit with an exit code 1.

The current output is:

```console
$ ./lint/asciidoctor-warnings.sh
Found 294 unresolved attributes
Unresolved attribute {assignedlabels} found in:
  labs/apoc/4.0/overview/apoc.trigger/index.html
  labs/apoc/4.0/overview/apoc.trigger/apoc.trigger.nodesByLabel/index.html
  labs/apoc/4.0/overview/index.html
Unresolved attribute {batch} found in:
  labs/kafka/4.0/kafka-connect/index.html
Unresolved attribute {_batch} found in:
  labs/apoc/4.1/graph-updates/periodic-execution/index.html
  labs/apoc/4.0/graph-updates/periodic-execution/index.html
Unresolved attribute {conf} found in:
  labs/apoc/4.1/comparing-graphs/fingerprinting/index.html
  labs/apoc/4.0/comparing-graphs/fingerprinting/index.html
Unresolved attribute {config} found in:
  labs/apoc/4.1/cypher-execution/run-cypher-scripts/index.html
  labs/apoc/4.1/virtual/nodes-collapse/index.html
  labs/apoc/4.1/virtual/virtual-graph/index.html
  labs/apoc/4.1/import/xls/index.html
  labs/apoc/4.1/import/html/index.html
  labs/apoc/4.1/import/web-apis/index.html
  labs/apoc/4.1/overview/apoc.load/apoc.load.csv/index.html
  labs/apoc/4.1/overview/apoc.load/index.html
  labs/apoc/4.1/overview/apoc.load/apoc.load.xls/index.html
  labs/apoc/4.1/overview/apoc.meta/apoc.meta.data/index.html
  labs/apoc/4.1/overview/apoc.meta/apoc.meta.schema/index.html
  labs/apoc/4.1/overview/apoc.meta/index.html
  labs/apoc/4.1/overview/index.html
  labs/apoc/4.1/overview/apoc.graph/apoc.graph.validateDocument/index.html
  labs/apoc/4.1/overview/apoc.graph/apoc.graph.fromDocument/index.html
  labs/apoc/4.1/overview/apoc.graph/index.html
  labs/apoc/4.1/graph-updates/graph-refactoring/merge-nodes/index.html
  labs/apoc/4.0/cypher-execution/run-cypher-scripts/index.html
  labs/apoc/4.0/virtual/nodes-collapse/index.html
  labs/apoc/4.0/virtual/virtual-graph/index.html
  labs/apoc/4.0/import/xls/index.html
  labs/apoc/4.0/import/html/index.html
  labs/apoc/4.0/import/web-apis/index.html
  labs/apoc/4.0/overview/apoc.load/apoc.load.csv/index.html
  labs/apoc/4.0/overview/apoc.load/index.html
  labs/apoc/4.0/overview/apoc.load/apoc.load.xls/index.html
  labs/apoc/4.0/overview/apoc.meta/apoc.meta.data/index.html
  labs/apoc/4.0/overview/apoc.meta/apoc.meta.schema/index.html
  labs/apoc/4.0/overview/apoc.meta/index.html
  labs/apoc/4.0/overview/index.html
  labs/apoc/4.0/overview/apoc.graph/apoc.graph.validateDocument/index.html
  labs/apoc/4.0/overview/apoc.graph/apoc.graph.fromDocument/index.html
  labs/apoc/4.0/overview/apoc.graph/index.html
  labs/apoc/4.0/graph-updates/graph-refactoring/merge-nodes/index.html
Unresolved attribute {connectionmap} found in:
  labs/apoc/4.1/database-integration/load-ldap/index.html
  labs/apoc/4.1/overview/apoc.load/apoc.load.ldap/index.html
  labs/apoc/4.1/overview/apoc.load/index.html
  labs/apoc/4.1/overview/index.html
  labs/apoc/4.0/database-integration/load-ldap/index.html
  labs/apoc/4.0/overview/apoc.load/apoc.load.ldap/index.html
  labs/apoc/4.0/overview/apoc.load/index.html
  labs/apoc/4.0/overview/index.html
Unresolved attribute {creatednodes} found in:
  labs/apoc/4.1/overview/apoc.trigger/apoc.trigger.add/index.html
  labs/apoc/4.1/overview/apoc.trigger/index.html
  labs/apoc/4.1/overview/index.html
  labs/apoc/4.0/overview/apoc.trigger/apoc.trigger.add/index.html
  labs/apoc/4.0/overview/apoc.trigger/index.html
  labs/apoc/4.0/overview/index.html
Unresolved attribute {data} found in:
  labs/apoc/4.1/overview/apoc.map/apoc.map.updateTree/index.html
  labs/apoc/4.1/overview/apoc.map/index.html
  labs/apoc/4.1/overview/index.html
  labs/apoc/4.1/data-structures/map-functions/index.html
  labs/apoc/4.0/overview/apoc.map/apoc.map.updateTree/index.html
  labs/apoc/4.0/overview/apoc.map/index.html
  labs/apoc/4.0/overview/index.html
  labs/apoc/4.0/data-structures/map-functions/index.html
Unresolved attribute {deletednodes} found in:
  labs/apoc/4.1/overview/apoc.trigger/apoc.trigger.add/index.html
  labs/apoc/4.1/overview/apoc.trigger/index.html
  labs/apoc/4.1/overview/index.html
  labs/apoc/4.0/overview/apoc.trigger/apoc.trigger.add/index.html
  labs/apoc/4.0/overview/apoc.trigger/index.html
  labs/apoc/4.0/overview/index.html
Unresolved attribute {duration} found in:
  labs/apoc/4.1/misc/utility-functions/index.html
  labs/apoc/4.0/misc/utility-functions/index.html
Unresolved attribute {environment} found in:
  labs/kafka/4.0/cud-file-format/index.html
  labs/kafka/4.0/sink-strategies/index.html
  labs/kafka/4.0/consumer-configuration/index.html
Unresolved attribute {events} found in:
  labs/kafka/4.0/streams/index.html
  labs/kafka/4.0/consumer/index.html
Unresolved attribute {first} found in:
  labs/apoc/4.1/data-structures/map-functions/index.html
  labs/apoc/4.0/data-structures/map-functions/index.html
Unresolved attribute {id} found in:
  developer/spring-data-neo4j-rx/index.html
  developer/movie-database/index.html
  labs/kafka/4.0/cud-file-format/index.html
Unresolved attribute {json} found in:
  labs/apoc/4.1/virtual/virtual-graph/index.html
  labs/apoc/4.1/overview/apoc.json/apoc.json.path/index.html
  labs/apoc/4.1/overview/apoc.json/index.html
  labs/apoc/4.1/overview/index.html
  labs/apoc/4.1/overview/apoc.graph/apoc.graph.validateDocument/index.html
  labs/apoc/4.1/overview/apoc.graph/apoc.graph.fromDocument/index.html
  labs/apoc/4.1/overview/apoc.graph/index.html
  labs/apoc/4.0/virtual/virtual-graph/index.html
  labs/apoc/4.0/overview/apoc.json/apoc.json.path/index.html
  labs/apoc/4.0/overview/apoc.json/index.html
  labs/apoc/4.0/overview/index.html
  labs/apoc/4.0/overview/apoc.graph/apoc.graph.validateDocument/index.html
  labs/apoc/4.0/overview/apoc.graph/apoc.graph.fromDocument/index.html
  labs/apoc/4.0/overview/apoc.graph/index.html
Unresolved attribute {maps} found in:
  labs/apoc/4.1/overview/apoc.map/apoc.map.mergeList/index.html
  labs/apoc/4.1/overview/apoc.map/index.html
  labs/apoc/4.1/overview/index.html
  labs/apoc/4.1/data-structures/map-functions/index.html
  labs/apoc/4.0/overview/apoc.map/apoc.map.mergeList/index.html
  labs/apoc/4.0/overview/apoc.map/index.html
  labs/apoc/4.0/overview/index.html
  labs/apoc/4.0/data-structures/map-functions/index.html
Unresolved attribute {nodeoperators} found in:
  labs/apoc/4.1/virtual/graph-grouping/index.html
  labs/apoc/4.0/virtual/graph-grouping/index.html
Unresolved attribute {params} found in:
  labs/apoc/4.1/cypher-execution/cypher-multiple-statements/index.html
  labs/apoc/4.1/cypher-execution/running-cypher/index.html
  labs/apoc/4.1/virtual/virtual-graph/index.html
  labs/apoc/4.1/export/csv/index.html
  labs/apoc/4.1/export/json/index.html
  labs/apoc/4.1/overview/apoc.cypher/index.html
  labs/apoc/4.1/overview/apoc.cypher/apoc.cypher.runTimeboxed/index.html
  labs/apoc/4.1/overview/apoc.cypher/apoc.cypher.runMany/index.html
  labs/apoc/4.1/overview/apoc.export/apoc.export.json.query/index.html
  labs/apoc/4.1/overview/apoc.export/apoc.export.xls.query/index.html
  labs/apoc/4.1/overview/apoc.export/apoc.export.csv.query/index.html
  labs/apoc/4.1/overview/index.html
  labs/apoc/4.1/overview/apoc.graph/index.html
  labs/apoc/4.1/overview/apoc.graph/apoc.graph.fromCypher/index.html
  labs/apoc/4.0/cypher-execution/cypher-multiple-statements/index.html
  labs/apoc/4.0/cypher-execution/running-cypher/index.html
  labs/apoc/4.0/virtual/virtual-graph/index.html
  labs/apoc/4.0/export/csv/index.html
  labs/apoc/4.0/export/json/index.html
  labs/apoc/4.0/overview/apoc.cypher/index.html
  labs/apoc/4.0/overview/apoc.cypher/apoc.cypher.runTimeboxed/index.html
  labs/apoc/4.0/overview/apoc.cypher/apoc.cypher.runMany/index.html
  labs/apoc/4.0/overview/apoc.export/apoc.export.json.query/index.html
  labs/apoc/4.0/overview/apoc.export/apoc.export.xls.query/index.html
  labs/apoc/4.0/overview/apoc.export/apoc.export.csv.query/index.html
  labs/apoc/4.0/overview/index.html
  labs/apoc/4.0/overview/apoc.graph/index.html
  labs/apoc/4.0/overview/apoc.graph/apoc.graph.fromCypher/index.html
Unresolved attribute {price} found in:
  labs/kafka/4.0/kafka-connect/index.html
  labs/kafka/4.0/streams/index.html
  labs/kafka/4.0/sink-strategies/index.html
  labs/kafka/4.0/consumer/index.html
Unresolved attribute {properties} found in:
  labs/apoc/4.1/virtual/virtual-graph/index.html
  labs/apoc/4.1/overview/index.html
  labs/apoc/4.1/overview/apoc.graph/apoc.graph.fromPath/index.html
  labs/apoc/4.1/overview/apoc.graph/apoc.graph.fromData/index.html
  labs/apoc/4.1/overview/apoc.graph/apoc.graph.fromPaths/index.html
  labs/apoc/4.1/overview/apoc.graph/index.html
  labs/apoc/4.1/overview/apoc.graph/apoc.graph.fromCypher/index.html
  labs/apoc/4.1/overview/apoc.graph/apoc.graph.fromDB/index.html
  labs/apoc/4.1/overview/apoc.graph/apoc.graph.from/index.html
  labs/apoc/4.0/virtual/virtual-graph/index.html
  labs/apoc/4.0/overview/index.html
  labs/apoc/4.0/overview/apoc.graph/apoc.graph.fromPath/index.html
  labs/apoc/4.0/overview/apoc.graph/apoc.graph.fromData/index.html
  labs/apoc/4.0/overview/apoc.graph/apoc.graph.fromPaths/index.html
  labs/apoc/4.0/overview/apoc.graph/index.html
  labs/apoc/4.0/overview/apoc.graph/apoc.graph.fromCypher/index.html
  labs/apoc/4.0/overview/apoc.graph/apoc.graph.fromDB/index.html
  labs/apoc/4.0/overview/apoc.graph/apoc.graph.from/index.html
Unresolved attribute {reloperators} found in:
  labs/apoc/4.1/virtual/graph-grouping/index.html
  labs/apoc/4.0/virtual/graph-grouping/index.html
Unresolved attribute {removedlabels} found in:
  labs/apoc/4.0/overview/apoc.trigger/index.html
  labs/apoc/4.0/overview/apoc.trigger/apoc.trigger.nodesByLabel/index.html
  labs/apoc/4.0/overview/index.html
Unresolved attribute {_retry} found in:
  labs/apoc/4.1/graph-updates/periodic-execution/index.html
  labs/apoc/4.0/graph-updates/periodic-execution/index.html
Unresolved attribute {searchmap} found in:
  labs/apoc/4.1/database-integration/load-ldap/index.html
  labs/apoc/4.1/overview/apoc.load/apoc.load.ldap/index.html
  labs/apoc/4.1/overview/apoc.load/index.html
  labs/apoc/4.1/overview/index.html
  labs/apoc/4.0/database-integration/load-ldap/index.html
  labs/apoc/4.0/overview/apoc.load/apoc.load.ldap/index.html
  labs/apoc/4.0/overview/apoc.load/index.html
  labs/apoc/4.0/overview/index.html
Unresolved attribute {second} found in:
  labs/apoc/4.1/data-structures/map-functions/index.html
  labs/apoc/4.0/data-structures/map-functions/index.html
Unresolved attribute {url} found in:
  developer/movie-database/index.html
  labs/apoc/4.1/import/xls/index.html
  labs/apoc/4.1/import/load-csv/index.html
  labs/apoc/4.0/import/xls/index.html
  labs/apoc/4.0/import/load-csv/index.html
```

Since Asciidoctor/Antora does not give us the AsciiDoc source for a missing attribute, I'm using `grep` on the `build/site` directory.
So, it might contain a few false-positive but overall I think it gives us a good idea of where we should look.

Once #8 is merged, I will update this pull request to run this script when `npm run lint` is executed.
