### PR TITLE
Avoid right TOC overflow on the footer

### DIFF
--- a/ui/src/css/toc.css
+++ b/ui/src/css/toc.css
@@ -35,7 +35,7 @@
 
 .toc.sidebar .toc-menu ul {
   max-height: var(--toc-height);
-  /* overflow-y: auto; */
+  overflow-y: auto;
   scrollbar-width: none;
 }
 


### PR DESCRIPTION
| Before | After |
| -- | -- |
| ![toc-over-before](https://user-images.githubusercontent.com/333276/95098616-3640b600-072f-11eb-948f-06fd4fe50a3f.png) |  ![toc-over-after](https://user-images.githubusercontent.com/333276/95098614-35a81f80-072f-11eb-9c69-da132250f2db.png)

In action:

![max-height-toc](https://user-images.githubusercontent.com/333276/95098667-43f63b80-072f-11eb-847b-bf57358fd3a9.gif)


Arguably, it would be better to reduce the number of items in the TOC but I think that we should make sure that the UI looks good even when the content is not perfect.
