### PR TITLE
Enable the experimental attribute by default

### DIFF
--- a/kb.yml
+++ b/kb.yml
@@ -21,6 +21,7 @@ asciidoc:
   - ./extensions/remote-include/remote-include-processor
   - ./extensions/macros/macros
   attributes:
+    experimental: ''
     page-component: kb
     page-theme: kb
     page-cdn: /static/assets

--- a/labs-docs.yml
+++ b/labs-docs.yml
@@ -33,6 +33,7 @@ asciidoc:
   - ./extensions/remote-include/remote-include-processor
   - ./extensions/macros/macros
   attributes:
+    experimental: ''
     page-theme: labs
     page-cdn: /static/assets
     page-canonical-root: /labs

--- a/netlify-labs-docs.yml
+++ b/netlify-labs-docs.yml
@@ -30,4 +30,5 @@ asciidoc:
   - ./extensions/remote-include/remote-include-processor
   - ./extensions/macros/macros
   attributes:
+    experimental: ''
     page-theme: labs

--- a/netlify-preview.yml
+++ b/netlify-preview.yml
@@ -23,4 +23,5 @@ asciidoc:
   - ./extensions/remote-include/remote-include-processor
   - ./extensions/macros/macros
   attributes:
+    experimental: ''
     page-disabletracking: true

--- a/unversioned.yml
+++ b/unversioned.yml
@@ -26,4 +26,5 @@ asciidoc:
   - ./extensions/remote-include/remote-include-processor
   - ./extensions/macros/macros
   attributes:
+    experimental: ''
     page-cdn: /static/assets


### PR DESCRIPTION
Asciidoctor is using the `experimental` attribute (which, in practice, is no longer experimental) to enable the keyboard `kbd` macro.
I think we should enable it by default.