### PR TITLE
resolves #38 mock the content catalog to preview KB articles

### DIFF
--- a/ui/gulp.d/tasks/build-preview-pages.js
+++ b/ui/gulp.d/tasks/build-preview-pages.js
@@ -53,6 +53,11 @@ module.exports = (src, previewSrc, previewDest, sink = () => map()) => (done) =>
               uiModel.page.layout = doc.getAttribute('page-layout', 'default')
               uiModel.page.title = doc.getDocumentTitle()
               uiModel.page.contents = Buffer.from(doc.convert())
+              // REMIND: mock contentCatalog
+              uiModel.contentCatalog = {
+                getPages: () => [],
+                getById: () => null,
+              }
             }
             file.extname = '.html'
             try {

--- a/ui/preview-src/kb-article.adoc
+++ b/ui/preview-src/kb-article.adoc
@@ -1,0 +1,84 @@
+= How to estimate initial memory configuration
+:page-layout: kb-article
+:page-theme: kb
+:author: Dave Gordon
+:neo4j-versions: 2.3,3.0
+:tags: heap, memory, jvm, page-cache, cache
+:category: operations
+
+The initial and eventual memory configuration parameters can be a moving target, based on how your store changes in size and how your workload increases or changes over time.
+
+This guidance is meant for the initial configuration.
+
+In order to decide on an appropriate configuration, you need the following information:
+
+* Amount of physical memory on the machine hosting Neo4j.
+* Estimates of the following:
+** Number of nodes.
+** Number of relationships.
+** Average number of properties per node and per relationship.
+
+A fairly high-level rule of thumb is `Total Physical Memory = Heap + Page Cache + OS Memory`.
+
+Usually reserving 1-2GB for the OS is sufficient. The heap and page cache are detailed below.
+
+== First, we need to decide on a good heap size.
+
+A heap should not be overly large, as that can cause much longer Stop-the-World pauses when a full garbage collection (GC) cycle is needed.
+It should also be big enough to allow enough memory for your workload.
+On systems with a large amount of physical memory (>56GB), keeping the heap to 16GB and under typically works well.
+
+[source,cypher]
+----
+MATCH (m:Movie)
+OPTIONAL MATCH (m)<-[:WORKED_ON]-(a:Animator)
+WITH m, a
+WHERE m.releaseYear > 1999 AND a IS NOT NULL
+RETURN m, collect(a) as animators
+----
+
+== Second, consider the page cache.
+
+This is where the store files will be mapped in main memory for quicker access.
+The default page-cache size is 50% of the available memory.
+A good rule of thumb is Store `size + expected growth + 10%`.
+So, for a store that is 5GB in size, and you expect that to double in size in the next year, you would ideally allocate `5GB + 5GB + 1GB = 11GB`.
+
+[NOTE]
+This last section is no longer relevant for Neo4j versions 2.3 and later.
+
+== Lastly, let's look at the object cache options.
+
+The object cache is where nodes, relationships, and other objects are mapped to main memory.
+By default on Neo4j 2.2.x, this is set to High Performance Cache (hpc).
+On small stores (~10GB or smaller), this performs well.
+On larger stores, you will probably see better performance turning off the cache (set `cache_type=none`).
+
+If you are using the object cache and need to tune it further, consider starting with the `cache.memory_ratio` option.
+This is on-heap, so it is the percentage of the heap to use for object cache.
+The default is 50%, but you can increase this a bit (to as high as 65-70%), especially if the JVM is not using all of its heap consistently.
+
+== Install
+
+*Steps:*
+
+. Navigate to the NEO4J_HOME directory:
++
+[source,shell,role=noheader]
+----
+$ cd /var/lib/neo4j/
+----
+
+. Get the 3.0 software:
++
+[source,shell,role=noheader]
+----
+$ wget http://www.neo4j.com/customer/download/neo4j-enterprise-3.0.4-unix.tar.gz
+----
+
+. Backup the existing Neo4j 2.3.7 install:
++
+[source,shell,role=noheader]
+----
+$ ./neo4j-enterprise-2.3.7/bin/neo4j-backup -to /tmp/neo4j_2.3.7_backup -host 127.0.0.1
+----

--- a/ui/preview-src/ui-model.yml
+++ b/ui/preview-src/ui-model.yml
@@ -135,6 +135,9 @@ page:
     - content: Developer Template
       url: developer.html
       urlType: internal
+    - content: KB Article Template
+      url: kb-article.html
+      urlType: internal
 
 asciidoc:
   attributes:


### PR DESCRIPTION
@adam-cowley you can now preview KB article when running `npm run start` in the `ui` directory:

![kb-article-preview](https://user-images.githubusercontent.com/333276/97604153-7bde5f00-1a0d-11eb-8dac-85d9791eaa66.png)

Since I'm using a mock, some informations will be missing: tags, categories, authors... but we can fix this issue later.

resolves #38