### PR TITLE
We need to build the ui-bundle.zip before running lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     - run: npm install
     - run: npm install --prefix ui
 
-    - run: npm run lint
     - run: npm run lint --prefix ui
     - run: npm run build --prefix ui
+    - run: npm run lint
 
     - name: Sync UI Bundle to S3
       uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -19,6 +19,8 @@ jobs:
       with:
         node-version: '14'
     - run: npm install
+    - run: npm install --prefix ui
+    - run: npm run build --prefix ui
     - run: npm run lint
     - run: npm run build:unversioned
     - run: npm run build:developer-subfolders
@@ -47,7 +49,6 @@ jobs:
         AWS_REGION: 'eu-west-1'
         SOURCE_DIR: 'build/site/labs'
         DEST_DIR: 'labs'
-
 
     - name: Sync Developer Content
       uses: jakejarvis/s3-sync-action@master


### PR DESCRIPTION
The lint task relies on Antora playbooks (which reliy on a local `ui-bundle.zip` file). For instance:

https://github.com/neo4j-documentation/docs-refresh/blob/ea21f64889b98a345949dd03c468adb588570c7a/developer-subfolders.yml#L11

Since the `ui/build/ui-bundle.zip` file is not versioned anymore, we need to build the UI before we can run the `npm run lint` task.