### PR TITLE
refactor algolia indexing

### DIFF
--- a/algolia/constants.js
+++ b/algolia/constants.js
@@ -1,0 +1,75 @@
+module.exports = {
+  data: [
+    {
+      match: "developer/**/*.html",
+    },
+
+    // general labs folers
+    {
+      match: "labs/*/discussions/**/*.html",
+    },
+    {
+      match: "labs/*/how-to-guide/**/*.html",
+    },
+    {
+      match: "labs/*/installation/**/*.html",
+    },
+    {
+      match: "labs/*/reference/**/*.html",
+    },
+    {
+      match: "labs/*/tutorial/**/*.html",
+    },
+    {
+      match: "labs/*/acknowledgements/**/*.html",
+    },
+    {
+      match: "labs/*/graph-app/**/*.html",
+    },
+    {
+      match: "labs/*/troubleshooting/**/*.html",
+    },
+    {
+      match: "labs/*/index.html",
+    },
+
+    // ===== for versioned lab folders =====
+    // apoc
+    {
+      match: "labs/apoc/4.0/**/*.html",
+      version: "4.0",
+    },
+    {
+      match: "labs/apoc/4.1/**/*.html",
+      version: "4.1",
+    },
+
+    // etl
+    {
+      match: "labs/etl-tool/1.5.0/**/*.html",
+      version: "1.5.0",
+    },
+
+    // kafka
+    {
+      match: "labs/kafka/4.0/**/*.html",
+      version: "4.0",
+    },
+
+    // neo4j-helm
+    {
+      match: "labs/neo4j-helm/1.0.0/**/*.html",
+      version: "1.0.0",
+    },
+
+    // neo-semantics
+    {
+      match: "labs/neosemantics/4.0/**/*.html",
+      version: "4.0",
+    },
+    {
+      match: "labs/neosemantics/4.1/**/*.html",
+      version: "4.1",
+    },
+  ],
+};


### PR DESCRIPTION
@adam-cowley this PR refactors the algolia indexing of the developer content.

The property keys of the index object have been updated to reflect the naming convention specified here - https://github.com/neo-technology/neo4j.com/wiki/Algolia-Indexing-Schema

Also to not index different version of the same items, the logic to generate the `objectID` has been modified the version no. has been stripped out.

Also to be able to still store the available versions information, I have created a `constants.js` file and broken down the main `index.js` file into smaller functions so that it becomes easier to handle this part.

Feel free to refactor on top of this. I don't have the best knowledge, so there might be a better way to optimize the code.