### PR TITLE
use createInline to prevent asciidoctor error from label macro

### DIFF
--- a/extensions/macros/macros.js
+++ b/extensions/macros/macros.js
@@ -78,7 +78,8 @@ module.exports.register = function(registry, context) {
                 .join(' ')
             }
 
-            return `<span class="label label--${target}">${text}</span>`
+            const label = `<span class="label label--${target}">${text}</span>`
+            return self.createInline(parent, 'quoted', label)
         })
     })
 }

--- a/extensions/macros/package.json
+++ b/extensions/macros/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-documentation/macros",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Macros for building Neo4j Documentation",
   "main": "macros.js",
   "scripts": {


### PR DESCRIPTION
Adds the label content using `self.createInline` to prevent errors and warnings in Antora 3 logs.

This update works with Antora 2 as well as Antora 3.