### PR TITLE
Update labs-docs.yml - APOC 5.22

### DIFF
--- a/labs-docs.yml
+++ b/labs-docs.yml
@@ -8,7 +8,7 @@ content:
     branches: ['master']
     start_path: doc/docs
   - url: https://github.com/neo4j-contrib/neo4j-apoc-procedures
-    branches: ['5.21', '4.4', '4.3', '4.2', '4.1', '4.0']
+    branches: ['5.22', '4.4', '4.3', '4.2', '4.1', '4.0']
     start_path: docs/asciidoc
   - url: https://github.com/neo4j-labs/neosemantics
     branches: ['5.14','4.3', '4.2', '4.1', '4.0']


### PR DESCRIPTION
Updated APOC branch to the [latest Extended release's branch](https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/tag/5.22.0)