### PR TITLE
Replace Enterprise with Virtual Dedicated Cloud in labels

### DIFF
--- a/extensions/macros/macros.js
+++ b/extensions/macros/macros.js
@@ -53,7 +53,8 @@ const renameLabels = {
     'cluster-member-read-replica': 'READ_REPLICA',
     'cluster-member-single': 'SINGLE',
     'not-on-aura': 'Not Available on Aura',
-    'aura-db-enterprise': 'AuraDB Enterprise',
+    'aura-db-enterprise': 'AuraDB Virtual Dedicated Cloud',
+    'aura-db-vdc': 'AuraDB Virtual Dedicated Cloud',
 }
 
 module.exports.register = function(registry, context) {

--- a/extensions/macros/package.json
+++ b/extensions/macros/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-documentation/macros",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Macros for building Neo4j Documentation",
   "main": "macros.js",
   "scripts": {


### PR DESCRIPTION
Updates the macros extension to change the text from AuraDB labels.