### PR TITLE
[DEPRECATED] Removed the doc for the Labs Helm charts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,11 +42,9 @@ The action runs the `npm run build` command which builds the following playbooks
 
 - `unversioned.yml` - Developer guides at `neo4j.com/developer/*` and Labs pages at `neo4j.com/labs/*`
 - `labs-docs.yml` - Builds the documentation from remote sources into `neo4j.com/labs/{project}/{version}`
-  - link:https://neo4j.com/labs/neo4j-helm/1.0.0/[Helm^]
   - link:https://neo4j.com/labs/apoc/5/[APOC^]
   - link:https://neo4j.com/labs/neosemantics/4.0/[Neosemantics^]
   - link:https://neo4j.com/labs/kafka/4.0/[Neo4j Streams/Kafka^]
-  - link:https://neo4j.com/labs/neo4j-helm/1.0.0/[Helm^]
   - link:https://neo4j.com/labs/etl-tool/1.5.0/[ETL Tool^]
   - link:https://neo4j.com/labs/neodash/2.4/[NeoDash^]
   - link:https://neo4j.com/labs/neo4j-needle-starterkit/2.0/[Needle Starter Kit^]

--- a/labs-docs.yml
+++ b/labs-docs.yml
@@ -4,9 +4,6 @@ site:
 
 content:
   sources:
-  - url: https://github.com/neo4j-contrib/neo4j-helm.git
-    branches: ['master']
-    start_path: doc/docs
   - url: https://github.com/neo4j-contrib/neo4j-apoc-procedures
     branches: ['5.21', '4.4', '4.3', '4.2', '4.1', '4.0']
     start_path: docs/asciidoc


### PR DESCRIPTION
Removed all pages/docs/links for the Labs neo4j-helm as deprecated since 4.2 but still show up first in SEO results, which is confusing for customers (and even bad in some situation when they implement it without knowing we have the official charts and those ones are not gonna work for >v4.2)