### PR TITLE
Updated APOC Extended docs with 2025.04 version

### DIFF
--- a/labs-docs.yml
+++ b/labs-docs.yml
@@ -5,7 +5,7 @@ site:
 content:
   sources:
   - url: https://github.com/neo4j-contrib/neo4j-apoc-procedures
-    branches: ['5.26', '4.4', '4.3', '4.2', '4.1', '4.0']
+    branches: ['2025.04', '5.26', '4.4', '4.3', '4.2', '4.1', '4.0']
     start_path: docs/asciidoc
   - url: https://github.com/neo4j-labs/neosemantics
     branches: ['5.14','4.3', '4.2', '4.1', '4.0']


### PR DESCRIPTION
Updated APOC Extended docs with 2025.04 version

To check, since i'm not sure if it works correctly since `npm run build` after `npm i` returns a ` HTTPError: Response code 403 (Forbidden)`

\cc @adam-cowley